### PR TITLE
Update import path for app, start, and task

### DIFF
--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/main.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/main.py
@@ -7,7 +7,7 @@ def hello_world_task(data):
     return "hello world"
 
 
-@app(id="hello-world-app", path="/hello")
+@app(id="hello-world-app")
 def hello_world_app(data):
     return hello_world_task(data)
 

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/main.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/main.py
@@ -1,4 +1,4 @@
-from seaplane import app, start, task
+from seaplane.apps import app, start, task
 
 #Remember to add your SEAPLANE_API_KEY in .env file
 


### PR DESCRIPTION
These now live in `seaplane.apps`

I also got rid of the "path" argument to the app, since this sends a deprecation warning.